### PR TITLE
tell browser to go to 127.0.0.1 instead of 0.0.0.0

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -110,7 +110,7 @@ pub async fn entrypoint() -> Fallible<()> {
                 spawn(async move {
                     match wait_for_server(port).await {
                         Ok(_) => {
-                            let _ = open::that(format!("http://0.0.0.0:{port}/"));
+                            let _ = open::that(format!("http://127.0.0.1:{port}/"));
                         }
                         Err(e) => {
                             eprintln!("Failed to connect to server: {e}");


### PR DESCRIPTION
The browser is being told to go to host `0.0.0.0`, which is invalid. Many but not all browsers translate this to `127.0.0.1`, but not my browser.

The other uses of `0.0.0.0` appear correct to me but I didn't look closer after I got the `drill` command to work.