### PR TITLE
Add horizontal rule separator for flashcards

### DIFF
--- a/CHANGELOG.xml
+++ b/CHANGELOG.xml
@@ -7,6 +7,9 @@
             <change author="eudoxia0">
                 The session completed page now shows a button to shut down the server.
             </change>
+            <change author="claude">
+                Horizontal rule lines (`---`) are now ignored in flashcard content, allowing them to be used as visual separators between cards.
+            </change>
         </added>
         <changed>
             <change author="eudoxia0">


### PR DESCRIPTION
Lines containing only "---" are now filtered out from flashcard content. This allows users to use horizontal rules as visual separators between cards without affecting the card content itself, since <hr> elements serve no useful purpose in flashcard text.

Changes:
- Added Line::Separator variant to handle HR lines
- Added is_separator() helper function
- Modified state machine to ignore separator lines in all states
- Added comprehensive tests for HR separators in questions, answers, cloze cards, and between cards
- Updated CHANGELOG.xml

🤖 Generated with [Claude Code](https://claude.com/claude-code)