### PR TITLE
Add triple dash separator for flash messages [fix #27]

### DIFF
--- a/CHANGELOG.xml
+++ b/CHANGELOG.xml
@@ -7,6 +7,9 @@
             <change author="eudoxia0">
                 The session completed page now shows a button to shut down the server.
             </change>
+            <change author="claude">
+                Flashcards can now be separated using `---` as an explicit separator.
+            </change>
         </added>
         <changed>
             <change author="eudoxia0">


### PR DESCRIPTION
This commit adds support for using --- as an explicit flashcard separator.

Changes:
- Added Line::Separator variant to the parser
- Added is_separator() function to detect --- lines
- Updated Line::read() to classify --- as separator
- Updated state machine to handle separators:
  - Initial state: ignore (stay in Initial)
  - ReadingQuestion state: error (can't split Q/A)
  - ReadingAnswer state: finalize card, return to Initial
  - ReadingCloze state: finalize cloze, return to Initial
- Added comprehensive tests for separator functionality
- Updated CHANGELOG.xml

🤖 Generated with [Claude Code](https://claude.com/claude-code)