### PR TITLE
feat: add shortcut labels to buttons

### DIFF
--- a/src/cmd/drill/get.rs
+++ b/src/cmd/drill/get.rs
@@ -80,10 +80,34 @@ fn render_session_page(state: &ServerState, mutable: &MutableState) -> Fallible<
                 input id="good" type="submit" name="action" value="Good";
             },
             AnswerControls::Full => html! {
-                input id="forgot" type="submit" name="action" value="Forgot";
-                input id="hard" type="submit" name="action" value="Hard";
-                input id="good" type="submit" name="action" value="Good";
-                input id="easy" type="submit" name="action" value="Easy";
+                div.control-with-shortcut {
+                    input
+                        id="forgot" type="submit" name="action" value="Forgot";
+                    div.shortcut {
+                        "1"
+                    }
+                }
+                div.control-with-shortcut {
+                    input
+                        id="hard" type="submit" name="action" value="Hard";
+                    div.shortcut {
+                        "2"
+                    }
+                }
+                div.control-with-shortcut {
+                    input
+                        id="good" type="submit" name="action" value="Good";
+                    div.shortcut {
+                        "3"
+                    }
+                }
+                div.control-with-shortcut {
+                    input
+                        id="easy" type="submit" name="action" value="Easy";
+                    div.shortcut {
+                        "4"
+                    }
+                }
             },
         };
         html! {
@@ -102,7 +126,17 @@ fn render_session_page(state: &ServerState, mutable: &MutableState) -> Fallible<
             form action="/" method="post" {
                 (undo_button(undo_disabled))
                 div.spacer {}
-                input id="reveal" type="submit" name="action" value="Reveal" title="Show the answer";
+                div.control-with-shortcut {
+                    input
+                        id="reveal"
+                        type="submit"
+                        name="action"
+                        value="Reveal"
+                        title="Show the answer";
+                    div.shortcut {
+                        "Space"
+                    }
+                }
                 div.spacer {}
                 (end_button())
             }
@@ -255,7 +289,12 @@ fn undo_button(disabled: bool) -> Markup {
         }
     } else {
         html! {
-            input id="undo" type="submit" name="action" value="Undo" title="Undo last action";
+            div.control-with-shortcut {
+                input id="undo" type="submit" name="action" value="Undo" title="Undo last action";
+                div.shortcut {
+                    "U"
+                }
+            }
         }
     }
 }

--- a/src/cmd/drill/style.css
+++ b/src/cmd/drill/style.css
@@ -164,6 +164,47 @@ body {
             display: flex;
             justify-content: space-between;
 
+            .grades {
+                display: flex;
+                flex-direction: row;
+                justify-content: space-between;
+            }
+
+            .control-with-shortcut {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                background: white;
+                border: 1px solid #999;
+                padding: 7px 12px;
+                border-radius: 6px;
+                box-shadow: #ccc 0px 1px 3px 0px;
+
+                input {
+                    background: none;
+                    border: none;
+                    padding: 0;
+                    font-size: 16px;
+                    font-family: system-ui, -apple-system, "Helvetica Neue", sans-serif;
+                    font-weight: 600;
+                    cursor: pointer;
+                    box-shadow: none;
+
+                    &:disabled {
+                        cursor: not-allowed;
+                    }
+                }
+
+                .shortcut {
+                    margin-top: 6px;
+                    font-size: 12px;
+                    font-family: system-ui, -apple-system, "Helvetica Neue", sans-serif;
+                    color: #666;
+                    opacity: 0.8;
+                    letter-spacing: 0.02em;
+                }
+            }
+
             .spacer {
                 flex: 1;
             }
@@ -289,12 +330,6 @@ body {
 
             input {
                 margin: 6px 0;
-            }
-
-            .grades {
-                display: flex;
-                flex-direction: row;
-                justify-content: space-between;
             }
         }
     }


### PR DESCRIPTION
This PR adds labels below the buttons to show their respective shortcuts.

Screenshot:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c05351f6-b45b-4017-bb37-25d68754bfb1" />