### PR TITLE
Fix button text not visible on iOS Safari

### DIFF
--- a/src/cmd/drill/style.css
+++ b/src/cmd/drill/style.css
@@ -169,10 +169,13 @@ body {
             }
 
             input {
+                -webkit-appearance: none;
+                appearance: none;
                 background: white;
                 border: 1px solid #999;
                 padding: 7px 12px;
                 font-size: 16px;
+                color: black;
                 font-family:
                     system-ui,
                     -apple-system,


### PR DESCRIPTION
Fixes #89 

iOS Safari applies native form control styling that hides button text on input[type=submit] elements. Added -webkit-appearance: none and explicit color property to ensure text is visible.

Affects: Forgot, Hard, Good, Easy, Undo, Reveal, End buttons

Before / After
<img width="200" height="1280" alt="image" src="https://github.com/user-attachments/assets/dbda1a78-17f7-40ba-b401-e78eaf5a3109" /> / <img width="200" height="1280" alt="image" src="https://github.com/user-attachments/assets/9282925e-8faf-471d-8fa6-f67ed6ef18de" />

