### PR TITLE
Add Markdown Table and Syntax Highlighting Support

### DIFF
--- a/src/cmd/drill/script.js
+++ b/src/cmd/drill/script.js
@@ -22,6 +22,10 @@ document.addEventListener("DOMContentLoaded", function () {
     ],
     macros: MACROS,
   });
+  // Initialize syntax highlighting
+  if (typeof hljs !== "undefined") {
+    hljs.highlightAll();
+  }
   const cardContent = document.querySelector(".card-content");
   if (cardContent) {
     cardContent.style.opacity = "1";

--- a/src/cmd/drill/style.css
+++ b/src/cmd/drill/style.css
@@ -133,7 +133,8 @@ body {
                     ol,
                     ul,
                     blockquote,
-                    table {
+                    table,
+                    pre {
                         &:not(:last-child) {
                             margin-bottom: 16px;
                         }
@@ -143,6 +144,71 @@ body {
                         background: #f7f7f7;
                         border-left: 4px solid #ccc;
                         padding: 8px 12px;
+                    }
+
+                    table {
+                        border-collapse: collapse;
+                        width: 100%;
+                        font-size: 0.65em;
+                        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+                        line-height: 1.6;
+                        border: 1px solid #999;
+
+                        th,
+                        td {
+                            border: 1px solid #bbb;
+                            padding: 10px 14px;
+                            text-align: left;
+                            vertical-align: top;
+                        }
+
+                        th {
+                            background: #e8e8e8;
+                            font-weight: 600;
+                            border: 1px solid #999;
+                        }
+
+                        tbody tr:nth-child(odd) {
+                            background: #ffffff;
+                        }
+
+                        tbody tr:nth-child(even) {
+                            background: #f5f5f5;
+                        }
+
+                        code {
+                            font-size: 0.85em;
+                            background: #ececec;
+                        }
+                    }
+
+                    code {
+                        background: #f7f7f7;
+                        border: 1px solid #ddd;
+                        padding: 2px 6px;
+                        border-radius: 3px;
+                        font-family: "Menlo", "Monaco", "Courier New", monospace;
+                        font-size: 0.7em;
+                        color: inherit;
+                    }
+
+                    pre {
+                        background: #f7f7f7;
+                        border: 1px solid #ddd;
+                        border-radius: 4px;
+                        padding: 12px;
+                        overflow-x: auto;
+                        font-size: 0.7em;
+                        line-height: 1.5;
+
+                        code {
+                            background: transparent;
+                            border: none;
+                            padding: 0;
+                            border-radius: 0;
+                            font-size: 0.85em;
+                            color: inherit;
+                        }
                     }
 
                     audio {

--- a/src/cmd/drill/template.rs
+++ b/src/cmd/drill/template.rs
@@ -20,6 +20,9 @@ use crate::cmd::drill::katex::KATEX_AUTO_RENDER_JS_URL;
 use crate::cmd::drill::katex::KATEX_CSS_URL;
 use crate::cmd::drill::katex::KATEX_JS_URL;
 
+const HIGHLIGHT_JS_URL: &str = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js";
+const HIGHLIGHT_CSS_URL: &str = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css";
+
 pub fn page_template(body: Markup) -> Markup {
     html! {
         (DOCTYPE)
@@ -29,8 +32,10 @@ pub fn page_template(body: Markup) -> Markup {
                 meta name="viewport" content="width=device-width, initial-scale=1";
                 title { "hashcards" }
                 link rel="stylesheet" href=(KATEX_CSS_URL);
+                link rel="stylesheet" href=(HIGHLIGHT_CSS_URL);
                 script defer src=(KATEX_JS_URL) {};
                 script defer src=(KATEX_AUTO_RENDER_JS_URL) {};
+                script defer src=(HIGHLIGHT_JS_URL) {};
                 link rel="stylesheet" href="/style.css";
             }
             body {

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -14,6 +14,7 @@
 
 use pulldown_cmark::CowStr;
 use pulldown_cmark::Event;
+use pulldown_cmark::Options;
 use pulldown_cmark::Parser;
 use pulldown_cmark::Tag;
 use pulldown_cmark::html::push_html;
@@ -41,7 +42,9 @@ pub struct MarkdownRenderConfig {
 }
 
 pub fn markdown_to_html(config: &MarkdownRenderConfig, markdown: &str) -> Fallible<String> {
-    let parser = Parser::new(markdown);
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_TABLES);
+    let parser = Parser::new_ext(markdown, options);
     let events: Vec<Event<'_>> = parser
         .map(|event| match event {
             Event::Start(Tag::Image {


### PR DESCRIPTION
# Add Markdown Table and Syntax Highlighting Support
Adds support for rendering markdown tables and syntax highlighting for code blocks.

## Changes made
- **Enabled table support** in pulldown-cmark parser (`src/markdown.rs`)
    - Added `Options::ENABLE_TABLES` to parse markdown table syntax

- **Integrated highlight.js** for code block syntax highlighting (`src/cmd/drill/template.rs`)
    - Added [highlight.js](https://highlightjs.org/) with "github" theme
    - Supports all major programming languages (Rust, Python, JavaScript, SQL, etc.) 

## Preview
<img width="749" height="710" alt="image" src="https://github.com/user-attachments/assets/72828080-a8ee-4f79-817f-dc668019b49b" />

Markdown used in image above:
````
Q: What are the basic SQL query clauses?

A: SQL queries use clauses like `SELECT`, `WHERE`, and `ORDER BY` to retrieve and filter data.

| Clause | Purpose | Example |
| ------ | ------- | ------- |
| `SELECT` | Choose columns | `SELECT name, age FROM users` |
| `WHERE` | Filter rows | `WHERE age > 18` |
| `ORDER BY` | Sort results | `ORDER BY name ASC` |
| `LIMIT` | Restrict count | `LIMIT 10` |

Basic example:

```sql
SELECT username, email, created_at
FROM users
WHERE status = 'active'
  AND email IS NOT NULL
ORDER BY created_at DESC
LIMIT 25;
```
````