### PR TITLE
Support for escaping square brackets in cloze cards

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -461,7 +461,11 @@ impl Parser {
         // The full text of the card, without cloze deletion brackets.
         let clean_text: String = {
             let mut clean_text: Vec<u8> = Vec::new();
-            let mut image_mode = false;
+            // Flags to indicate should treat the next `[` or `]` differently.
+            // Set when the preceeding byte indicates it should be evaluated as
+            // markdown and not part of the cloze and therefore added to clean_text.
+            let mut image_mode = false; // ![
+            let mut escape_mode = false; // \[ and \]
             // We use `bytes` rather than `chars` because the cloze start/end
             // positions are byte positions, not character positions. This
             // keeps things tractable: bytes are well-understood, "characters"
@@ -471,11 +475,20 @@ impl Parser {
                     if image_mode {
                         clean_text.push(c);
                     }
+                    if escape_mode {
+                        escape_mode = false;
+                        clean_text.push(c);
+                    }
                 } else if c == b']' {
                     if image_mode {
                         // We are in image mode, so this closing bracket is
                         // part of a Markdown image.
                         image_mode = false;
+                        clean_text.push(c);
+                    } else if escape_mode {
+                        // We are in escape mode, so this closing bracket is
+                        // part of the markdown text.
+                        escape_mode = false;
                         clean_text.push(c);
                     }
                 } else if c == b'!' {
@@ -492,6 +505,19 @@ impl Parser {
                         }
                     }
                     clean_text.push(c);
+                } else if c == b'\\' {
+                    if !escape_mode {
+                        // escape_mode must be turned on *only* if the '\' is
+                        // immediately before a `[` or `]`. Otherwise, backslashes
+                        // in other positions would trigger it.
+                        let nextopt = text.as_bytes().get(bytepos + 1).copied();
+                        match nextopt {
+                            Some(b'[') | Some(b']') => {
+                                escape_mode = true;
+                            }
+                            _ => {}
+                        }
+                    }
                 } else {
                     clean_text.push(c);
                 }
@@ -511,10 +537,16 @@ impl Parser {
         let mut start = None;
         let mut index = 0;
         let mut image_mode = false;
+        let mut escape_mode = false;
         for (bytepos, c) in text.bytes().enumerate() {
             if c == b'[' {
                 if image_mode {
+                    // We are in image mode, so this closing bracket is part of a markdown image.
                     index += 1;
+                } else if escape_mode {
+                    // We are in escape mode, so this closing bracket is part of a markdown text.
+                    index += 1;
+                    escape_mode = false;
                 } else {
                     start = Some(index);
                 }
@@ -522,6 +554,10 @@ impl Parser {
                 if image_mode {
                     // We are in image mode, so this closing bracket is part of a markdown image.
                     image_mode = false;
+                    index += 1;
+                } else if escape_mode {
+                    // We are in escape mode, so this closing bracket is part of a markdown text.
+                    escape_mode = false;
                     index += 1;
                 } else if let Some(s) = start {
                     let end = index;
@@ -549,6 +585,19 @@ impl Parser {
                     }
                 }
                 index += 1;
+            } else if c == b'\\' {
+                if !escape_mode {
+                    // escape_mode must be turned on *only* if the '\' is
+                    // immediately before a `[` or `]`. Otherwise, backslashes
+                    // in other positions would trigger it.
+                    let nextopt = text.as_bytes().get(bytepos + 1).copied();
+                    match nextopt {
+                        Some(b'[') | Some(b']') => {
+                            escape_mode = true;
+                        }
+                        _ => {}
+                    }
+                }
             } else {
                 index += 1;
             }
@@ -694,6 +743,30 @@ mod tests {
         let cards = parser.parse(input)?;
 
         assert_cloze(&cards, "Foo bar ![](image.jpg) quux.", &[(4, 6), (23, 26)]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cloze_with_escaped_square_bracket() -> Result<(), ParserError> {
+        let input = "C: Key: [`\\[`]";
+        let parser = make_test_parser();
+        let cards = parser.parse(input)?;
+
+        println!("{:?}", cards[0].content());
+
+        assert_cloze(&cards, "Key: `[`", &[(5, 7)]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cloze_with_multiple_escaped_square_brackets() -> Result<(), ParserError> {
+        let input = "C: \\[markdown\\] [`\\[cloze\\]`]";
+        let parser = make_test_parser();
+        let cards = parser.parse(input)?;
+
+        println!("{:?}", cards[0].content());
+
+        assert_cloze(&cards, "[markdown] `[cloze]`", &[(11, 19)]);
         Ok(())
     }
 


### PR DESCRIPTION
When parsing a cloze card, if a `\` is present immediately before a `[` or `]` it is escaped by treating it as part of the markdown text.

This follows the same approach as escaping the [ in the markdown image sequence ![, where a boolean flag is set when we know a subset of the following characters should be escaped.

```
C: Key: [`\[`]

Action: [decrease playback speed.]
```

**Before**
<img width="636" height="309" alt="Screenshot 2026-01-08 at 23 43 24" src="https://github.com/user-attachments/assets/36e14a39-d50e-4c4a-b783-bcd9e58b0f0f" />

**After**
<img width="636" height="309" alt="Screenshot 2026-01-08 at 23 43 45" src="https://github.com/user-attachments/assets/e7367ce9-31fd-43ec-9c85-96cf8c57823c" />

**Revealed**
<img width="636" height="309" alt="Screenshot 2026-01-08 at 23 43 51" src="https://github.com/user-attachments/assets/b194a5db-efab-4edb-acfd-9e33991485f2" />


This was requested in https://github.com/eudoxia0/hashcards/issues/96.
