### PR TITLE
Add percent‑encoding support for media path resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,6 +510,7 @@ dependencies = [
  "log",
  "maud",
  "open",
+ "percent-encoding",
  "portpicker",
  "pulldown-cmark",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ env_logger = "0.11.8"
 log = "0.4.28"
 maud = "0.27.0"
 open = "5.3.2"
+percent-encoding = "2.3"
 pulldown-cmark = "0.13.0"
 rusqlite = { version = "0.38.0", features = ["bundled"] }
 serde = { version = "1.0.224", features = ["derive"] }

--- a/src/media/resolve.rs
+++ b/src/media/resolve.rs
@@ -16,6 +16,8 @@ use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
 
+use percent_encoding::percent_decode_str;
+
 use crate::error::ErrorReport;
 use crate::error::Fallible;
 
@@ -33,6 +35,14 @@ pub struct MediaResolver {
 pub struct MediaResolverBuilder {
     collection_path: Option<PathBuf>,
     deck_path: Option<PathBuf>,
+}
+
+/// Decode percent-encoded characters in a URL path (e.g., %20 to space).
+fn percent_decode(s: &str) -> Option<String> {
+    percent_decode_str(s)
+        .decode_utf8()
+        .ok()
+        .map(|s| s.into_owned())
 }
 
 /// Errors that can occur when resolving a file path.
@@ -75,7 +85,28 @@ impl MediaResolver {
     /// If the path string is a relative path, it will be resolved relative to
     /// the deck path. For deck-relative paths, parent (`..`) components are
     /// permitted.
+    ///
+    /// If the path is not found, the resolver will attempt to decode
+    /// percent-encoded characters (e.g., %20 to space) and try again.
     pub fn resolve(&self, path: &str) -> Result<PathBuf, ResolveError> {
+        // Try with original path first.
+        match self.resolve_inner(path) {
+            Ok(result) => Ok(result),
+            Err(ResolveError::InvalidPath) => {
+                // If not found, try with percent-decoded path as fallback.
+                if let Some(decoded) = percent_decode(path) {
+                    if decoded != path {
+                        return self.resolve_inner(&decoded);
+                    }
+                }
+                Err(ResolveError::InvalidPath)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Internal resolution logic.
+    fn resolve_inner(&self, path: &str) -> Result<PathBuf, ResolveError> {
         // Trim the path.
         let path: &str = path.trim();
 

--- a/src/media/validate.rs
+++ b/src/media/validate.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
 
+use percent_encoding::percent_decode_str;
 use pulldown_cmark::Event;
 use pulldown_cmark::Parser;
 use pulldown_cmark::Tag;
@@ -75,8 +77,10 @@ pub fn validate_media_files(cards: &[Card], base_dir: &Path) -> Fallible<()> {
                 match resolver.resolve(&path) {
                     Ok(_) => {}
                     Err(_) => {
+                        // Decode percent-encoded characters for better error display.
+                        let decoded_path: Cow<str> = percent_decode_str(&path).decode_utf8_lossy();
                         missing.insert(MissingMedia {
-                            file_path: path,
+                            file_path: decoded_path.into_owned(),
                             card_file: card.file_path().clone(),
                             card_lines: card.range(),
                         });


### PR DESCRIPTION
Some markdown editors (e.g. Obsidian) use URL-encoded for the media file. For example, file with name `Image 001.png` will be inserted as `![](Image%20001.png)`. This PR adds fallback for those %-encoded paths