### PR TITLE
make resource hostname customizable

### DIFF
--- a/CHANGELOG.xml
+++ b/CHANGELOG.xml
@@ -13,6 +13,9 @@
             <change author="kchousos">
                 Support `\(...\)` and `\[...\]` as LaTeX math delimiters, alongside `$...$` and `$$...$$`.
             </change>
+            <change author="IvanVergiliev">
+                Add `--resource-hostname` to customize rewritten media resource URLs.
+            </change>
         </added>
         <changed>
             <change author="eudoxia0">

--- a/README.md
+++ b/README.md
@@ -133,7 +133,11 @@ Options:
 
 - `--card-limit=<N>`: Limit the session to at most N cards.
 - `--new-card-limit=<N>`: Limit the number of new cards in the session.
+- `--host=<HOST>`: Bind the web server to a specific host address (default:
+  127.0.0.1).
 - `--port=<PORT>`: Use a specific port (default: 8000).
+- `--resource-hostname=<HOSTNAME>`: Use a specific hostname when rewriting
+  linked media resource URLs (default: localhost).
 - `--from-deck=<NAME>`: Only drill cards from a deck with the given name.
 - `--open-browser=<true|false>`: Whether or not to open the browser after the
   server starts (default: true).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,6 +48,9 @@ enum Command {
         /// The host address to bind to. Default is 127.0.0.1.
         #[arg(long, default_value = "127.0.0.1")]
         host: String,
+        /// The hostname to use when rewriting linked resource URLs. Default is localhost.
+        #[arg(long, default_value = "localhost")]
+        resource_hostname: String,
         /// The port to use for the web server. Default is 8000.
         #[arg(long, default_value_t = 8000)]
         port: u16,
@@ -119,6 +122,7 @@ pub async fn entrypoint() -> Fallible<()> {
             card_limit,
             new_card_limit,
             host,
+            resource_hostname,
             port,
             from_deck,
             open_browser,
@@ -143,6 +147,7 @@ pub async fn entrypoint() -> Fallible<()> {
             let config = ServerConfig {
                 directory,
                 host,
+                resource_hostname,
                 port,
                 session_started_at: Timestamp::now(),
                 card_limit,

--- a/src/cmd/drill/get.rs
+++ b/src/cmd/drill/get.rs
@@ -69,6 +69,7 @@ fn render_session_page(state: &ServerState, mutable: &MutableState) -> Fallible<
             .with_collection_path(coll_path)?
             .with_deck_path(deck_path)?
             .build()?,
+        resource_hostname: state.resource_hostname.clone(),
         port: state.port,
     };
     let card_content = render_card(&card, mutable.reveal, &config)?;

--- a/src/cmd/drill/mod.rs
+++ b/src/cmd/drill/mod.rs
@@ -26,6 +26,8 @@ mod template;
 #[cfg(test)]
 mod tests {
     use std::fs::create_dir_all;
+    use std::fs::write;
+    use std::path::Path;
 
     use portpicker::pick_unused_port;
     use reqwest::StatusCode;
@@ -41,6 +43,7 @@ mod tests {
     use crate::utils::wait_for_server;
 
     const TEST_HOST: &str = "127.0.0.1";
+    const TEST_RESOURCE_HOSTNAME: &str = "localhost";
 
     #[tokio::test]
     async fn test_start_server_on_non_existent_directory() -> Fallible<()> {
@@ -49,6 +52,7 @@ mod tests {
         let config = ServerConfig {
             directory: Some("./derpherp".to_string()),
             host: TEST_HOST.to_string(),
+            resource_hostname: TEST_RESOURCE_HOSTNAME.to_string(),
             port,
             session_started_at,
             card_limit: None,
@@ -75,6 +79,7 @@ mod tests {
         let config = ServerConfig {
             directory: Some(dir),
             host: TEST_HOST.to_string(),
+            resource_hostname: TEST_RESOURCE_HOSTNAME.to_string(),
             port,
             session_started_at,
             card_limit: None,
@@ -96,6 +101,7 @@ mod tests {
         let config = ServerConfig {
             directory: Some(directory),
             host: TEST_HOST.to_string(),
+            resource_hostname: TEST_RESOURCE_HOSTNAME.to_string(),
             port,
             session_started_at,
             card_limit: None,
@@ -191,6 +197,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_resource_hostname_rewrites_image_urls() -> Fallible<()> {
+        let port = pick_unused_port().unwrap();
+        let directory = create_tmp_copy_of_test_directory()?;
+        write(
+            Path::new(&directory).join("Deck.md"),
+            "Q: ![](foo.jpg)\nA: BAR",
+        )?;
+        let session_started_at = Timestamp::now();
+        let resource_hostname = "host.containers.internal";
+        let config = ServerConfig {
+            directory: Some(directory),
+            host: TEST_HOST.to_string(),
+            resource_hostname: resource_hostname.to_string(),
+            port,
+            session_started_at,
+            card_limit: None,
+            new_card_limit: None,
+            deck_filter: None,
+            shuffle: false,
+            answer_controls: AnswerControls::Full,
+            bury_siblings: false,
+        };
+        spawn(async move { start_server(config).await });
+        wait_for_server(TEST_HOST, port).await?;
+
+        let response = reqwest::get(format!("http://{TEST_HOST}:{port}/")).await?;
+        assert!(response.status().is_success());
+        let html = response.text().await?;
+        assert!(html.contains(&format!(
+            "src=\"http://{resource_hostname}:{port}/file/foo.jpg\""
+        )));
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_undo() -> Fallible<()> {
         let port = pick_unused_port().unwrap();
         let directory = create_tmp_copy_of_test_directory()?;
@@ -198,6 +240,7 @@ mod tests {
         let config = ServerConfig {
             directory: Some(directory),
             host: TEST_HOST.to_string(),
+            resource_hostname: TEST_RESOURCE_HOSTNAME.to_string(),
             port,
             session_started_at,
             card_limit: None,
@@ -247,6 +290,7 @@ mod tests {
         let config = ServerConfig {
             directory: Some(directory),
             host: TEST_HOST.to_string(),
+            resource_hostname: TEST_RESOURCE_HOSTNAME.to_string(),
             port,
             session_started_at,
             card_limit: None,
@@ -278,6 +322,7 @@ mod tests {
         let config = ServerConfig {
             directory: Some(directory),
             host: TEST_HOST.to_string(),
+            resource_hostname: TEST_RESOURCE_HOSTNAME.to_string(),
             port,
             session_started_at,
             card_limit: None,
@@ -309,6 +354,7 @@ mod tests {
         let config = ServerConfig {
             directory: Some(directory),
             host: TEST_HOST.to_string(),
+            resource_hostname: TEST_RESOURCE_HOSTNAME.to_string(),
             port,
             session_started_at,
             card_limit: None,
@@ -358,6 +404,7 @@ mod tests {
         let config = ServerConfig {
             directory: Some(directory),
             host: TEST_HOST.to_string(),
+            resource_hostname: TEST_RESOURCE_HOSTNAME.to_string(),
             port,
             session_started_at,
             card_limit: None,

--- a/src/cmd/drill/server.rs
+++ b/src/cmd/drill/server.rs
@@ -87,6 +87,7 @@ impl Display for AnswerControls {
 pub struct ServerConfig {
     pub directory: Option<String>,
     pub host: String,
+    pub resource_hostname: String,
     pub port: u16,
     pub session_started_at: Timestamp,
     pub card_limit: Option<usize>,
@@ -166,6 +167,7 @@ pub async fn start_server(config: ServerConfig) -> Fallible<()> {
 
     let state = ServerState {
         port: config.port,
+        resource_hostname: config.resource_hostname,
         directory,
         macros,
         total_cards: due_today.len(),

--- a/src/cmd/drill/state.rs
+++ b/src/cmd/drill/state.rs
@@ -32,6 +32,7 @@ use crate::types::timestamp::Timestamp;
 #[derive(Clone)]
 pub struct ServerState {
     pub port: u16,
+    pub resource_hostname: String,
     pub directory: PathBuf,
     pub macros: Vec<(String, String)>,
     pub total_cards: usize,

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -40,6 +40,8 @@ fn is_audio_file(url: &str) -> bool {
 pub struct MarkdownRenderConfig {
     /// A media resolver.
     pub resolver: MediaResolver,
+    /// The hostname where linked media resources are exposed.
+    pub resource_hostname: String,
     /// The port where the server is exposed.
     pub port: u16,
 }
@@ -192,6 +194,7 @@ fn is_in_ranges(pos: usize, ranges: &[Range<usize>]) -> bool {
 
 fn modify_url(url: &str, config: &MarkdownRenderConfig) -> Fallible<String> {
     let port = config.port;
+    let hostname = &config.resource_hostname;
     let path: String = config
         .resolver
         .resolve(url)
@@ -200,7 +203,7 @@ fn modify_url(url: &str, config: &MarkdownRenderConfig) -> Fallible<String> {
         })?
         .display()
         .to_string();
-    Ok(format!("http://localhost:{port}/file/{path}"))
+    Ok(format!("http://{hostname}:{port}/file/{path}"))
 }
 
 #[cfg(test)]
@@ -222,6 +225,7 @@ mod tests {
                 .with_collection_path(coll_path)?
                 .with_deck_path(PathBuf::from("deck.md"))?
                 .build()?,
+            resource_hostname: "localhost".to_string(),
             port: 1234,
         };
         Ok(config)
@@ -235,6 +239,19 @@ mod tests {
         assert_eq!(
             html,
             "<p><img src=\"http://localhost:1234/file/image.png\" alt=\"alt\" /></p>\n"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_markdown_to_html_custom_resource_hostname() -> Fallible<()> {
+        let markdown = "![alt](@/image.png)";
+        let mut config = make_test_config()?;
+        config.resource_hostname = "host.containers.internal".to_string();
+        let html = markdown_to_html(&config, markdown)?;
+        assert_eq!(
+            html,
+            "<p><img src=\"http://host.containers.internal:1234/file/image.png\" alt=\"alt\" /></p>\n"
         );
         Ok(())
     }


### PR DESCRIPTION
I run hashcards from within a local VM that I access by IP. Since the resource URLs have `localhost` hardcoded as the hostname, they're not showing up successfully over the VM IP.

This PR makes the base hostname customizable to solve this problem.

# Test plan
- unit and e2e tests pass
- confirmed images that were not showing up previously now display successfully