### PR TITLE
Error on unparseable text between flashcard separators

### DIFF
--- a/CHANGELOG.xml
+++ b/CHANGELOG.xml
@@ -5,6 +5,11 @@
                 Add `--resource-hostname` to customize rewritten media resource URLs.
             </change>
         </changed>
+        <fixed>
+            <change author="eudoxia0">
+                Stray text between flashcards produces an error.
+            </change>
+        </fixed>
     </unreleased>
     <releases>
         <release version="0.4.0" date="2026-07-17">

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -295,7 +295,17 @@ impl Parser {
                     start_line: line_num,
                 }),
                 Line::Separator => Ok(State::Start),
-                Line::Text(_) => Ok(State::Start),
+                Line::Text(text) => {
+                    if text.trim().is_empty() {
+                        Ok(State::Start)
+                    } else {
+                        Err(ParserError::new(
+                            "Found text that doesn't parse as a flashcard. Did you forget a 'Q:' or 'C:' tag?",
+                            self.file_path.clone(),
+                            line_num,
+                        ))
+                    }
+                }
                 Line::Eof => Ok(State::End),
             },
             State::ReadingQuestion {
@@ -1239,6 +1249,29 @@ A: Genetic material."#,
                 answer,
             } if question == "baz" && answer == "quux"
         ));
+        Ok(())
+    }
+
+    #[test]
+    fn test_unparseable_text_between_separators_errors() -> Result<(), ParserError> {
+        let input = "Q: foo\nA: bar\n\n---\n\nI'm a mistake!\n\n---\n\nQ: baz\nA: quux";
+        let parser = make_test_parser();
+        let result = parser.parse(input);
+
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(e.to_string().contains("doesn't parse as a flashcard"));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_unparseable_text_at_start_errors() -> Result<(), ParserError> {
+        let input = "This is stray text.\n\nQ: foo\nA: bar";
+        let parser = make_test_parser();
+        let result = parser.parse(input);
+
+        assert!(result.is_err());
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Text between two `---` separators (or before the first card, or after the last) that doesn't parse as a `Q:`/`A:`/`C:` card was previously discarded silently by the parser's `State::Start` handler.
- This meant a cloze card missing its `C:` tag (or any other stray non-blank text) would just vanish instead of raising a parse error.
- `State::Start` now only tolerates blank lines; any non-blank text triggers a `ParserError` naming the file and line, e.g. "Found text that doesn't parse as a flashcard. Did you forget a 'Q:' or 'C:' tag?"

## Test plan
- [x] Added `test_unparseable_text_between_separators_errors`, reproducing the exact repro case (stray text between two `---` separators)
- [x] Added `test_unparseable_text_at_start_errors` for stray text before the first card
- [x] Full test suite passes (129/138; the 9 failing `cmd::drill` server tests are pre-existing sandbox/port-binding failures, reproduced identically on `master`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01D6xDeqM3LrG74xhgHxX4xo)_