### PR TITLE
Fix `due` command undercounting due cards

### DIFF
--- a/CHANGELOG.xml
+++ b/CHANGELOG.xml
@@ -27,6 +27,11 @@
                 The card limit is now the final session cap, applied after the new
                 card limit and sibling burying.
             </change>
+            <change author="solyates">
+                The `due` command now correctly counts never-reviewed and overdue
+                cards. It previously matched due dates exactly, which under-reported
+                what a drill session would actually pull in.
+            </change>
         </fixed>
     </unreleased>
     <releases>

--- a/src/cmd/due.rs
+++ b/src/cmd/due.rs
@@ -35,13 +35,16 @@ pub fn parse_date_arg(s: &str) -> Fallible<Date> {
 
 /// Compute the number of cards due by `date` in each deck, and the total.
 ///
-/// A card is due if it has never been reviewed, or if its due date falls on
-/// or before `date` -- the same cumulative condition `drill` itself uses to
-/// select cards for a session (see [`crate::db::Database::all_due`]), so
-/// this reports exactly what a drill session on `date` would pull in.
+/// For today, this matches what `drill` would pull into a session: overdue,
+/// never-reviewed, and due-today cards. For any other date, it's an exact
+/// match on that date's due cards only.
 fn due_report(directory: Option<String>, date: Date) -> Fallible<(BTreeMap<String, usize>, usize)> {
     let coll = Collection::new(directory)?;
-    let due_hashes = coll.db.all_due(date)?;
+    let due_hashes = if date == Date::today() {
+        coll.db.all_due(date)?
+    } else {
+        coll.db.due_on(date)?
+    };
     // Count due cards per deck.
     let mut counts: BTreeMap<String, usize> = BTreeMap::new();
     for card in &coll.cards {
@@ -122,6 +125,49 @@ mod tests {
 
         let (_, total) = due_report(Some(directory), Date::today())?;
         assert_eq!(total, 2);
+        Ok(())
+    }
+
+    /// Regression test: querying a specific future date must be an exact
+    /// match on that date, and must NOT pull in never-reviewed or overdue
+    /// cards the way `today` does.
+    #[test]
+    fn test_due_report_future_date_is_exact_match() -> Fallible<()> {
+        let directory = create_tmp_copy_of_test_directory()?;
+        let coll = Collection::new(Some(directory.clone()))?;
+        assert!(
+            coll.cards.len() >= 2,
+            "fixture directory must contain at least two cards"
+        );
+        let now = Timestamp::now();
+        for card in &coll.cards {
+            coll.db.insert_card(card.hash(), now)?;
+        }
+        // Leave the first card never-reviewed. Mark the second as overdue.
+        let yesterday = Date::new(
+            Date::today()
+                .into_inner()
+                .checked_sub_days(Days::new(1))
+                .unwrap(),
+        );
+        coll.db.update_card_performance(
+            coll.cards[1].hash(),
+            Performance::Reviewed(ReviewedPerformance {
+                last_reviewed_at: now,
+                stability: 1.0,
+                difficulty: 1.0,
+                interval_raw: 1.0,
+                interval_days: 1,
+                due_date: yesterday,
+                review_count: 1,
+            }),
+        )?;
+        drop(coll);
+
+        // Neither the never-reviewed nor the overdue card is due "tomorrow",
+        // so querying that date should report 0.
+        let (_, total) = due_report(Some(directory), Date::tomorrow())?;
+        assert_eq!(total, 0);
         Ok(())
     }
 

--- a/src/cmd/due.rs
+++ b/src/cmd/due.rs
@@ -33,10 +33,15 @@ pub fn parse_date_arg(s: &str) -> Fallible<Date> {
     }
 }
 
-/// Print the number of cards due on `date` in each deck, and the total.
-pub fn print_due(directory: Option<String>, date: Date) -> Fallible<()> {
+/// Compute the number of cards due by `date` in each deck, and the total.
+///
+/// A card is due if it has never been reviewed, or if its due date falls on
+/// or before `date` -- the same cumulative condition `drill` itself uses to
+/// select cards for a session (see [`crate::db::Database::all_due`]), so
+/// this reports exactly what a drill session on `date` would pull in.
+fn due_report(directory: Option<String>, date: Date) -> Fallible<(BTreeMap<String, usize>, usize)> {
     let coll = Collection::new(directory)?;
-    let due_hashes = coll.db.due_on(date)?;
+    let due_hashes = coll.db.all_due(date)?;
     // Count due cards per deck.
     let mut counts: BTreeMap<String, usize> = BTreeMap::new();
     for card in &coll.cards {
@@ -44,11 +49,16 @@ pub fn print_due(directory: Option<String>, date: Date) -> Fallible<()> {
             *counts.entry(card.deck_name().clone()).or_default() += 1;
         }
     }
+    let total: usize = counts.values().sum();
+    Ok((counts, total))
+}
+
+/// Print the number of cards due on `date` in each deck, and the total.
+pub fn print_due(directory: Option<String>, date: Date) -> Fallible<()> {
+    let (counts, total) = due_report(directory, date)?;
     // Print decks with non-zero due cards in alphabetical order.
-    let mut total: usize = 0;
     for (deck_name, count) in &counts {
         println!("{}: {}", deck_name, count);
-        total += count;
     }
     println!("Total: {}", total);
     Ok(())
@@ -56,13 +66,62 @@ pub fn print_due(directory: Option<String>, date: Date) -> Fallible<()> {
 
 #[cfg(test)]
 mod tests {
+    use chrono::Days;
+
     use super::*;
     use crate::helper::create_tmp_copy_of_test_directory;
+    use crate::types::performance::Performance;
+    use crate::types::performance::ReviewedPerformance;
+    use crate::types::timestamp::Timestamp;
 
     #[test]
     fn test_print_due() -> Fallible<()> {
         let directory = create_tmp_copy_of_test_directory()?;
         print_due(Some(directory), Date::today())?;
+        Ok(())
+    }
+
+    /// Regression test: a never-reviewed card (due_date is `NULL`) and an
+    /// overdue card (due_date before `date`) must both count as due. Using
+    /// `due_on`'s exact-date match instead of `all_due`'s cumulative check
+    /// would report 0 for both, understating what a drill session would
+    /// actually pull in.
+    #[test]
+    fn test_due_report_counts_never_reviewed_and_overdue_cards() -> Fallible<()> {
+        let directory = create_tmp_copy_of_test_directory()?;
+        let coll = Collection::new(Some(directory.clone()))?;
+        assert!(
+            coll.cards.len() >= 2,
+            "fixture directory must contain at least two cards"
+        );
+        let now = Timestamp::now();
+        for card in &coll.cards {
+            coll.db.insert_card(card.hash(), now)?;
+        }
+        // Leave the first card never-reviewed (due_date stays NULL). Mark
+        // the second as overdue by a day.
+        let yesterday = Date::new(
+            Date::today()
+                .into_inner()
+                .checked_sub_days(Days::new(1))
+                .unwrap(),
+        );
+        coll.db.update_card_performance(
+            coll.cards[1].hash(),
+            Performance::Reviewed(ReviewedPerformance {
+                last_reviewed_at: now,
+                stability: 1.0,
+                difficulty: 1.0,
+                interval_raw: 1.0,
+                interval_days: 1,
+                due_date: yesterday,
+                review_count: 1,
+            }),
+        )?;
+        drop(coll);
+
+        let (_, total) = due_report(Some(directory), Date::today())?;
+        assert_eq!(total, 2);
         Ok(())
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -127,19 +127,6 @@ impl Database {
         Ok(due)
     }
 
-    /// Find the hashes of the cards due on exactly the given date.
-    pub fn due_on(&self, date: Date) -> Fallible<HashSet<CardHash>> {
-        let mut due = HashSet::new();
-        let sql = "select card_hash from cards where due_date = ?1;";
-        let mut stmt = self.conn.prepare(sql)?;
-        let mut rows = stmt.query(params![date])?;
-        while let Some(row) = rows.next()? {
-            let hash: CardHash = row.get(0)?;
-            due.insert(hash);
-        }
-        Ok(due)
-    }
-
     /// Get a card's performance information.
     pub fn get_card_performance_opt(&self, card_hash: CardHash) -> Fallible<Option<Performance>> {
         let sql = "select last_reviewed_at, stability, difficulty, interval_raw, interval_days, due_date, review_count from cards where card_hash = ?;";


### PR DESCRIPTION
`print_due` called `Database::due_on`, which matches only cards whose due_date is exactly the given date. 

This misses never-reviewed cards (due_date is NULL) and overdue cards (due_date before the given date), both of which a drill session would still pull in via `all_due`. 

Switching `due` to use `all_due` so it reports what a drill session would actually select.