### PR TITLE
Forgotten cards should stay due the same day, not roll to tomorrow

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -449,6 +449,40 @@ mod tests {
         Ok(())
     }
 
+    /// A forgotten reviewed card is persisted as due today and is selected
+    /// when a later session queries today's due cards.
+    #[test]
+    fn test_forgotten_reviewed_card_is_due_in_later_same_day_session() -> Fallible<()> {
+        let db = Database::new(":memory:")?;
+        let card_hash = CardHash::hash_bytes(b"a");
+        let now = Timestamp::now();
+        let three_days = chrono::Duration::days(3);
+        db.insert_card(card_hash, now)?;
+
+        let previous = ReviewedPerformance {
+            last_reviewed_at: Timestamp::new(now.into_inner() - three_days),
+            stability: 3.17,
+            difficulty: 5.28,
+            interval_raw: 3.17,
+            interval_days: 3,
+            due_date: now.date(),
+            review_count: 1,
+        };
+        let forgotten = crate::types::performance::update_performance(
+            Performance::Reviewed(previous),
+            Grade::Forgot,
+            now,
+        );
+        db.update_card_performance(card_hash, Performance::Reviewed(forgotten))?;
+
+        assert_eq!(forgotten.interval_days, 0);
+        assert_eq!(forgotten.due_date, now.date());
+        assert!(db.all_due(now.date())?.contains(&card_hash));
+        let tomorrow = Date::new(now.date().into_inner() + chrono::Duration::days(1));
+        assert!(db.all_due(tomorrow)?.contains(&card_hash));
+        Ok(())
+    }
+
     /// `get_card_performance` fails if the card does not exist.
     #[test]
     fn test_get_performance_nonexistent() -> Fallible<()> {

--- a/src/types/performance.rs
+++ b/src/types/performance.rs
@@ -32,17 +32,8 @@ use crate::types::timestamp::Timestamp;
 /// The desired recall probability.
 const TARGET_RECALL: f64 = 0.9;
 
-/// The minimum review interval in days, for grades other than [`Grade::Forgot`].
+/// The minimum review interval in days.
 const MIN_INTERVAL: f64 = 1.0;
-
-/// The minimum review interval in days for a [`Grade::Forgot`] review.
-///
-/// Forgotten cards are allowed to come due again the same day, rather than
-/// being pushed to tomorrow: `hashcards` has no Anki-style intraday
-/// relearning steps, so a same-day floor is what lets a forgotten card
-/// resurface in a later session on the same day (see `all_due`), instead of
-/// disappearing until tomorrow even though you just missed it.
-const MIN_INTERVAL_FORGOT: f64 = 0.0;
 
 /// The maximum review interval in days.
 const MAX_INTERVAL: f64 = 256.0;
@@ -104,14 +95,14 @@ pub fn update_performance(
             (stability, difficulty, review_count)
         }
     };
-    let min_interval: Interval = match grade {
-        Grade::Forgot => MIN_INTERVAL_FORGOT,
-        Grade::Hard | Grade::Good | Grade::Easy => MIN_INTERVAL,
-    };
     let interval_raw: Interval = interval(TARGET_RECALL, stability);
-    let interval_rounded: Interval = interval_raw.round();
-    let interval_clamped: Interval = interval_rounded.clamp(min_interval, MAX_INTERVAL);
-    let interval_days: i64 = interval_clamped as i64;
+    // Forgotten cards remain due on the review date.
+    let interval_days: i64 = match grade {
+        Grade::Forgot => 0,
+        Grade::Hard | Grade::Good | Grade::Easy => {
+            interval_raw.round().clamp(MIN_INTERVAL, MAX_INTERVAL) as i64
+        }
+    };
     let interval_duration: Duration = Duration::days(interval_days);
     let due_date: Date = Date::new(today + interval_duration);
     ReviewedPerformance {

--- a/src/types/performance.rs
+++ b/src/types/performance.rs
@@ -32,8 +32,17 @@ use crate::types::timestamp::Timestamp;
 /// The desired recall probability.
 const TARGET_RECALL: f64 = 0.9;
 
-/// The minimum review interval in days.
+/// The minimum review interval in days, for grades other than [`Grade::Forgot`].
 const MIN_INTERVAL: f64 = 1.0;
+
+/// The minimum review interval in days for a [`Grade::Forgot`] review.
+///
+/// Forgotten cards are allowed to come due again the same day, rather than
+/// being pushed to tomorrow: `hashcards` has no Anki-style intraday
+/// relearning steps, so a same-day floor is what lets a forgotten card
+/// resurface in a later session on the same day (see `all_due`), instead of
+/// disappearing until tomorrow even though you just missed it.
+const MIN_INTERVAL_FORGOT: f64 = 0.0;
 
 /// The maximum review interval in days.
 const MAX_INTERVAL: f64 = 256.0;
@@ -95,9 +104,13 @@ pub fn update_performance(
             (stability, difficulty, review_count)
         }
     };
+    let min_interval: Interval = match grade {
+        Grade::Forgot => MIN_INTERVAL_FORGOT,
+        Grade::Hard | Grade::Good | Grade::Easy => MIN_INTERVAL,
+    };
     let interval_raw: Interval = interval(TARGET_RECALL, stability);
     let interval_rounded: Interval = interval_raw.round();
-    let interval_clamped: Interval = interval_rounded.clamp(MIN_INTERVAL, MAX_INTERVAL);
+    let interval_clamped: Interval = interval_rounded.clamp(min_interval, MAX_INTERVAL);
     let interval_days: i64 = interval_clamped as i64;
     let interval_duration: Duration = Duration::days(interval_days);
     let due_date: Date = Date::new(today + interval_duration);
@@ -185,5 +198,56 @@ mod tests {
         assert!(approx_eq(interval_raw, 25.80));
         assert_eq!(interval_days, 26);
         assert_eq!(review_count, 2);
+    }
+
+    /// Forgetting a new card must not push its due date to tomorrow: with no
+    /// intraday relearning steps, that's the only way a forgotten card can
+    /// resurface later the same day.
+    #[test]
+    fn test_forgetting_new_card_is_due_same_day() {
+        let reviewed_at = Timestamp::now();
+        let today = reviewed_at.date();
+        let result = update_performance(Performance::New, Grade::Forgot, reviewed_at);
+        assert_eq!(result.interval_days, 0);
+        assert_eq!(result.due_date, today);
+    }
+
+    /// Forgetting an already-reviewed card must likewise stay due today,
+    /// not get pushed a full day out.
+    #[test]
+    fn test_forgetting_reviewed_card_is_due_same_day() {
+        let now = Timestamp::now();
+        let today = now.date();
+        let duration = Duration::days(3);
+        let last_reviewed_at = Timestamp::new(now.into_inner() - duration);
+        let initial_perf = ReviewedPerformance {
+            last_reviewed_at,
+            stability: 3.17,
+            difficulty: 5.28,
+            interval_raw: 3.17,
+            interval_days: 3,
+            due_date: Date::new(today.into_inner() + duration),
+            review_count: 1,
+        };
+        let result = update_performance(Performance::Reviewed(initial_perf), Grade::Forgot, now);
+        assert_eq!(result.interval_days, 0);
+        assert_eq!(result.due_date, today);
+    }
+
+    /// Forgetting the same card twice in one day (e.g. across two separate
+    /// `drill` sessions) must produce a well-formed, still-diminishing
+    /// stability rather than panicking or producing nonsense -- `elapsed
+    /// days == 0` is an ordinary case for FSRS, not a special one.
+    #[test]
+    fn test_forgetting_same_card_twice_same_day() {
+        let now = Timestamp::now();
+        let first = update_performance(Performance::New, Grade::Forgot, now);
+        assert_eq!(first.due_date, now.date());
+
+        let second = update_performance(Performance::Reviewed(first), Grade::Forgot, now);
+        assert_eq!(second.due_date, now.date());
+        assert!(second.stability > 0.0);
+        assert!(second.stability.is_finite());
+        assert_eq!(second.review_count, 2);
     }
 }


### PR DESCRIPTION
`MIN_INTERVAL` (1 day) is applied to every grade, including Forgot. In practice this means grading a card "forgot" always pushes its due_date to tomorrow — even for a brand-new card, whose raw FSRS interval on Forgot is typically well under a day (~0.4 days).

hashcards has no Anki-style intraday relearning steps (by design, per the "Simple" principle in the README), so the only way a forgotten card can come back up in a later session on the same day is if its `due_date` is allowed to stay today. Right now it can't — you have to wait until tomorrow, which doesn't match what "Forgot" should mean.

This adds a separate, lower floor (`MIN_INTERVAL_FORGOT = 0.0`) used only for `Grade::Forgot`, leaving Hard/Good/Easy untouched. It's a one-constant, one-branch change — no session/queue changes, no schema changes, still fully day-granular (no new intraday state). It composes naturally with `all_due(today)` (used by drill and, after #199, by due), so a forgotten card just shows up as due again whenever you next open a session that day.

Added three tests: forgetting a new card, forgetting a previously-reviewed card, and forgetting the same card twice same-day (checking `elapsed_days == 0` doesn't break the stability update - FSRS handles that as an ordinary case, not a special one).

Happy to adjust the floor value if you'd rather it not be exactly 0 (e.g. leaving a small epsilon), just picked 0 since nothing downstream treats `interval_days` as a denominator.